### PR TITLE
Bugfix/fetch

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -40,7 +40,7 @@ export const fetchRecipes = () => dispatch => {
     payload: data
   }))
   .then(data => console.log(data))
-  .then(error => dispatch({
+  .catch(error => dispatch({
     type: FETCH_RECIPES_FAILED,
     payload: error
   }))

--- a/src/components/recipe/RecipeList.js
+++ b/src/components/recipe/RecipeList.js
@@ -24,6 +24,8 @@ class RecipeList extends Component {
     })
     .then(data => console.log(data, 'I am the being fetched from componentDidMount'))
     .then(error => console.log(error))
+
+    this.props.fetchRecipes()
   }
   
 }

--- a/src/reducers/recipesReducer.js
+++ b/src/reducers/recipesReducer.js
@@ -21,7 +21,7 @@ export default (state=initialState, action) => {
     console.log('success', action.payload)
       return {
         ...state,
-        recipes: action.payload,
+        recipes: action.payload.data.recipes,
         isPending: false
       }
     case FETCH_RECIPES_FAILED:


### PR DESCRIPTION
# What this pull request does:

- Calls fetchRecipes action creator in the RecipeList component
Otherwise the request is never made to the api in the first place.

- Replaces the last then() blocks by a catch in fetchRecipes action creator 
Otherwise the action would always dispatch a FETCH_RECIPES_SUCCESS & FETCH_RECIPES_FAILED
Now it only dispatches FETCH_RECIPES_FAILED in the case of an error

- Handle FETCH_RECIPES_SUCCESS action by accessing the correct value in the reducer 
action.payload.recipes