### PR TITLE
Persist API recipes

### DIFF
--- a/src/components/recipe/RenderAPIrecipes.js
+++ b/src/components/recipe/RenderAPIrecipes.js
@@ -8,8 +8,9 @@ import SearchBar from '../SearchBar'
 
 class RenderAPIrecipes extends Component {
   componentDidMount = () => {
-    const { fetchRecipes } = this.props
-    fetchRecipes()
+    const { fetchRecipes, recipes } = this.props
+    !recipes.recipes.length && fetchRecipes()
+    console.log(localStorage)
   }
 
   onSubmit = formValues => {

--- a/src/index.js
+++ b/src/index.js
@@ -3,13 +3,18 @@ import ReactDOM from 'react-dom'
 import './index.css'
 import App from './App'
 import { Provider } from 'react-redux'
-import { store } from './store'
+import { store, persistor } from './store'
 import "materialize-css/dist/css/materialize.min.css"
+import { PersistGate } from 'redux-persist/integration/react'
+import LoaderProgressBar from './components/LoaderProgressBar'
+
 
 store.firebaseAuthIsReady.then(() => {
   ReactDOM.render(
     <Provider store={store}>
-      <App />
+      <PersistGate loading={ <div className='container'><LoaderProgressBar /></div>} persistor={persistor}>
+        <App />
+      </PersistGate>
     </Provider>,
   document.getElementById('root'))
 })

--- a/src/store.js
+++ b/src/store.js
@@ -4,11 +4,21 @@ import thunk from 'redux-thunk'
 import { reduxFirestore, getFirestore } from 'redux-firestore'
 import { reactReduxFirebase, getFirebase } from 'react-redux-firebase'
 import fbConfig from './config/fbConfig'
+import storage from 'redux-persist/lib/storage'
+import { persistReducer, persistStore } from 'redux-persist'
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
 
+const persistConfig = {
+  key: 'recipes',
+  storage: storage,
+  whitelist: ['recipes'],
+}
+
+const persistedReducer = persistReducer(persistConfig, rootReducer)
+
 export const store = createStore(
-  rootReducer,
+  persistedReducer,
   composeEnhancers(
     applyMiddleware(
       thunk.withExtraArgument({
@@ -24,6 +34,9 @@ export const store = createStore(
     })
   )
 )
+
+export const persistor = persistStore(store)
+
 
 export const rrfConfig = {
   fbConfig,


### PR DESCRIPTION
What this branch does.
- Install [Redux-Persist](https://github.com/rt2zz/redux-persist), which help to persist redux state using the local storage.
- Persist 'Picked Recipes that are coming from the Spoonacular API.
        - In case there are no recipes, new recipes will be fetched,
        - In case fo new search, new recipes will be fetched.

The purpose of this change is to reduce API calls and improve user experience.